### PR TITLE
riskreports integration

### DIFF
--- a/R/reports.R
+++ b/R/reports.R
@@ -9,7 +9,7 @@
 #' @examples
 #' pkg_ref <- riskmetric::pkg_ref("ggplot2", source = "pkg_cran_remote")
 #' pkg_assessment <- riskmetric::pkg_assess(pkg_ref)
-#' generate_riskreport(pkg_ref, pkg_assessment)
+#' generate_riskreports(pkg_ref, pkg_assessment)
 #'
 #' @export
 generate_riskreports <- function(pkg_reference,

--- a/R/reports.R
+++ b/R/reports.R
@@ -36,8 +36,6 @@ generate_riskreports <- function(pkg_reference,
         outfile <- riskreports::package_report(
           package_name = ref$name,
           package_version = ref$version,
-          # FIXME: still doesn't work with the template file from the package
-          template_path = system.file("report/_pkg_template.qmd", package = "pharmapkgs"),
           params = list(
             assessment_path = assessment_path
           ),


### PR DESCRIPTION
This PR is to discuss the integration between riskreports and pharmapkgs, discussed a bit on  #17 
1) The errors generating the report using `riskreports::package_report`: I've tested this PR with the current main branch and the report is generated without problems. 
2) riskreports template requires a path to a file with the riskmetrics assessment. This could be changed to directly pass the object, but the reports would be less flexible to be built from the command line. This could simplify the CI part a bit but make it less flexible for companies. 
3) It was [also discussed](https://github.com/pharmaR/pharmapkgs/pull/17#issuecomment-2585978439), if riskmetrics' scores should be calculated as part of the CI. This might depend on the upcoming riskmetric development plan, so waiting on this PR.