### PR TITLE
21 after updating a package meta info is lost

### DIFF
--- a/R/PACKAGES.R
+++ b/R/PACKAGES.R
@@ -149,9 +149,11 @@ update_packages <- function(old_local_packages, new_local_packages) {
   old <- data[[1]]
   new <- data[[2]]
 
+  columns_ordered <- .get_packages_field_order(old, new)
+
   old_packages <- old[!old$Package %in% new$Package, ]
   new_packages <- rbind(old_packages, new)
-  new_packages[order(new_packages$Package), ]
+  new_packages[order(new_packages$Package), columns_ordered]
 }
 
 #' Save PACKAGES info to the local repository.

--- a/R/PACKAGES.R
+++ b/R/PACKAGES.R
@@ -24,8 +24,10 @@ get_packages <- function(
 
   on.exit(close(connection))
 
-  read.dcf(connection, all = TRUE) |>
-    as.data.frame()
+  tryCatch(
+    as.data.frame(read.dcf(connection, all = TRUE)),
+    error = function(e) data.frame(Package = NA_character_, Version = NA_character_)
+  )
 }
 
 #' Identify new or newer packages.

--- a/R/PACKAGES.R
+++ b/R/PACKAGES.R
@@ -127,6 +127,15 @@ score_packages <- function(
   )
 }
 
+#' @export
+add_score_to_packages <- function(packages, scores) {
+  merge(
+    x = packages,
+    y = scores,
+    by = c("Package", "Version")
+  )
+}
+
 #' Update local PACKAGES info.
 #'
 #' @param old_local_packages Data frame with PACKAGES info currently stored in the repo.

--- a/R/constants.R
+++ b/R/constants.R
@@ -20,12 +20,12 @@ RHUB_BASE_URL <- "https://raw.githubusercontent.com/r-hub/repos/main"
 #' @keywords internal
 PHARMAPKGS_BASE_URL <- system.file("repos", package = "pharmapkgs", mustWork = TRUE)
 
-#' The default order of PACKAGES fields as in r-hub/repos.
+#' The order of PACKAGES fields as in r-hub/repos.
 #' Notice that some fields are duplicated, this is intentional
 #' and is done to account for different naming conventions that
 #' occurred at different times (e.g. `DownloadURL` and `DownloadUrl`).
 #' @keywords internal
-PACKAGES_FIELDS <- c(
+RHUB_PACKAGES_FIELDS <- c(
   "Package",
   "Version",
   "Depends",
@@ -47,5 +47,51 @@ PACKAGES_FIELDS <- c(
   "GraphicsAPIVersion",
   "GraphicsApiVersion",
   "InternalsID",
-  "InternalsId"
+  "InternalsId",
+  "SystemRequirements",
+  "Enhances",
+  "LinkingTo"
+)
+
+#' The order of PACKAGES fields as in CRAN.
+#' @keywords internal
+CRAN_PACKAGES_FIELDS <- c(
+  "Package",
+  "Version",
+  "Depends",
+  "Suggests",
+  "License",
+  "MD5sum",
+  "NeedsCompilation",
+  "Imports",
+  "LinkingTo",
+  "Enhances",
+  "License_restricts_use",
+  "OS_type",
+  "Priority",
+  "License_is_FOSS",
+  "Archs",
+  "Path"
+)
+
+#' The order of PACKAGES fields as in R-universe.
+#' @keywords internal
+RUNIVERSE_PACKAGES_FIELDS <- c(
+  "Package",
+  "Version",
+  "License",
+  "NeedsCompilation",
+  "Filesize",
+  "SHA256",
+  "Depends",
+  "Suggests",
+  "MD5sum",
+  "Imports",
+  "LinkingTo",
+  "Enhances",
+  "Archs",
+  "Priority",
+  "OS_type",
+  "License_restricts_use",
+  "License_is_FOSS"
 )

--- a/R/constants.R
+++ b/R/constants.R
@@ -19,3 +19,33 @@ RHUB_BASE_URL <- "https://raw.githubusercontent.com/r-hub/repos/main"
 #' Base URL for the pharmapkgs repository.
 #' @keywords internal
 PHARMAPKGS_BASE_URL <- system.file("repos", package = "pharmapkgs", mustWork = TRUE)
+
+#' The default order of PACKAGES fields as in r-hub/repos.
+#' Notice that some fields are duplicated, this is intentional
+#' and is done to account for different naming conventions that
+#' occurred at different times (e.g. `DownloadURL` and `DownloadUrl`).
+#' @keywords internal
+PACKAGES_FIELDS <- c(
+  "Package",
+  "Version",
+  "Depends",
+  "Suggests",
+  "License",
+  "DownloadURL",
+  "DownloadUrl",
+  "OS",
+  "Os",
+  "Arch",
+  "Built",
+  "Filesize",
+  "SHA256",
+  "Sha256",
+  "RVersion",
+  "Platform",
+  "File",
+  "Imports",
+  "GraphicsAPIVersion",
+  "GraphicsApiVersion",
+  "InternalsID",
+  "InternalsId"
+)

--- a/R/pipeline.R
+++ b/R/pipeline.R
@@ -4,7 +4,7 @@ github_actions <- function() {
   remote_packages <- get_packages()
   local_packages <- get_packages(base_url = .config$local_base)
   new_packages <- diff_packages(remote_packages, local_packages)
-  scoring_result <- score_packages(new_packages, remote_packages)
+  scoring_result <- score_packages(new_packages)
   scored_packages <- add_score_to_packages(remote_packages, scoring_result$scored_packages)
   new_local_packages <- update_packages(local_packages, scored_packages)
   generate_riskreports(scoring_result$package_refs, scoring_result$package_assessments)

--- a/R/pipeline.R
+++ b/R/pipeline.R
@@ -4,8 +4,9 @@ github_actions <- function() {
   remote_packages <- get_packages()
   local_packages <- get_packages(base_url = .config$local_base)
   new_packages <- diff_packages(remote_packages, local_packages)
-  scoring_result <- score_packages(new_packages)
-  new_local_packages <- update_packages(local_packages, scoring_result$scored_packages)
+  scoring_result <- score_packages(new_packages, remote_packages)
+  scored_packages <- add_score_to_packages(remote_packages, scoring_result$scored_packages)
+  new_local_packages <- update_packages(local_packages, scored_packages)
   generate_riskreports(scoring_result$package_refs, scoring_result$package_assessments)
   write_packages(new_local_packages)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -48,10 +48,13 @@ global_filters <- function() {
   list(df1, df2)
 }
 
-.get_packages_field_order <- function(old_packages, new_packages) {
-  meta_fields <- PACKAGES_FIELDS[
-    PACKAGES_FIELDS %in% names(old_packages) |
-      PACKAGES_FIELDS %in% names(new_packages)
+.get_packages_field_order <- function(
+    old_packages,
+    new_packages,
+    core_fields = RHUB_PACKAGES_FIELDS) {
+  meta_fields <- core_fields[
+    core_fields %in% names(old_packages) |
+      core_fields %in% names(new_packages)
   ]
 
   unique(c(

--- a/R/utils.R
+++ b/R/utils.R
@@ -47,3 +47,16 @@ global_filters <- function() {
 
   list(df1, df2)
 }
+
+.get_packages_field_order <- function(old_packages, new_packages) {
+  meta_fields <- PACKAGES_FIELDS[
+    PACKAGES_FIELDS %in% names(old_packages) |
+      PACKAGES_FIELDS %in% names(new_packages)
+  ]
+
+  unique(c(
+    meta_fields,
+    names(old_packages),
+    names(new_packages)
+  ))
+}

--- a/tests/testthat/test-PACKAGES.R
+++ b/tests/testthat/test-PACKAGES.R
@@ -92,6 +92,22 @@ describe("score_packages", {
   })
 })
 
+describe("add_score_to_packages", {
+  it("adds score data to package metadata while retaining both", {
+    packages <- data.frame(
+      Package = c("A", "B"),
+      Version = c("1.0", "2.0"),
+      DownloadURL = c("url1", "url2")
+    )
+    scores <- data.frame(Package = c("A", "B"), Version = c("1.0", "2.0"), score = c(1, 2))
+
+    actual_output <- add_score_to_packages(packages, scores)
+
+    expect_equal(nrow(actual_output), 2)
+    expect_named(actual_output, c("Package", "Version", "DownloadURL", "score"))
+  })
+})
+
 describe("update_packages", {
   it("returns a data.frame with added new packages", {
     old_local_packages <- data.frame(Package = c("A", "B"), Version = c("1.0", "2.0"))


### PR DESCRIPTION
Closes #21 

## Description

This PR address an issue when after scoring a package, only the scoring data is saved to PACKAGES, while the core metadata (downloadURL, rversion, depends, etc) is lost.

As a side-track, this PR also improves consistency in fields order in PACKAGEs file, as well as addresses an issue when github_actions() pipeline won't work when local PACKAGES file is empty. THe latter is fixed in the scope of this PR, to prepare a complete reset of the local PACKAGES file.