### PR TITLE
feat: introduce a mechanism to explicitly exclude packages from scoring

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -39,3 +39,10 @@ PHARMAPKGS_EXCLUDED_METRICS <- paste(
   "assess_r_cmd_check", # takes forever to compute
   sep = ","
 )
+
+#' List of packages to exclude from the assessment.
+#' For example, packages that fail to be assessed by the riskmetric.
+#' @keywords internal
+EXCLUDED_PACKAGES <- readLines(
+  system.file("config", "excluded-packages.txt", package = "pharmapkgs")
+)

--- a/inst/config/excluded-packages.txt
+++ b/inst/config/excluded-packages.txt
@@ -1,0 +1,2 @@
+acss.data
+AntAngioCOOL


### PR DESCRIPTION
This PR introduces the ability to provide a list of packages to exclude from the repository.

One of the reasons for this is described [here](https://github.com/pharmaR/riskmetric/issues/362#issuecomment-2658338031) - it is not clear why exactly riskmetric fails, so at least I can handle some edge cases post-factum after a failed workflow..