### PR TITLE
34 update unit testing ci config

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,8 +5,10 @@ on:
   push:
 
 env:
-    PHARMAPKGS_REMOTE_REPO: https://raw.githubusercontent.com/r-hub/repos/main
+    PHARMAPKGS_REMOTE_REPO:  https://cloud.r-project.org/
     PHARMAPKGS_LIMIT: 5
+    PHARMAPKGS_EXCLUDED_METRICS: ${{ vars.PHARMAPKGS_EXCLUDED_METRICS || 'assess_covr_coverage,assess_r_cmd_check' }}
+    LOGGER_LOG_LEVEL: DEBUG
 
 jobs:
     main:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,10 +3,6 @@ name: Unit tests
 on:
   workflow_dispatch:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-    types: ready_for_review
 
 env:
     PHARMAPKGS_REMOTE_REPO: https://raw.githubusercontent.com/r-hub/repos/main

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,4 +24,4 @@ jobs:
 
         - name: Run unit tests
           shell: Rscript {0}
-          run: devtools::test()
+          run: devtools::test(stop_on_failure = TRUE)

--- a/tests/testthat/test-PACKAGES.R
+++ b/tests/testthat/test-PACKAGES.R
@@ -117,7 +117,7 @@ describe("add_score_to_packages", {
       Version = c("1.0", "2.0"),
       DownloadURL = c("url1", "url2")
     )
-    scores <- data.frame(Package = c("A", "B"), score = c(1, 2))
+    scores <- data.frame(Package = c("A", "B"), Version = c("1.0", "2.0"), score = c(1, 2))
 
     actual_output <- add_score_to_packages(packages, scores)
 


### PR DESCRIPTION
Closes #34 

## Description

This pull request addresses the following problems related to unit tests executed in the CI:
- First and foremost, `devtools::test()` by default does not fail the pipeline. CI is passing, whereas in fact the tests are failing.
  - This is resolved with `devtools::test(stop_on_failure=TRUE)`
- Unit tests are not always executed, so for now they are enabled on every push to every branch
- Environment variables in the test suite are now up to date
- Failing test is fixed


NB: force push is to remove changes related to R CMD CHECK, since I created a separate issue for this.