### PR TITLE
Disable website search

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,6 +6,7 @@ website:
     title: "pharmapkgs: riskreports"
     site-url: https://pharmar.github.io/pharmapkgs
     description: List of validated R packages.
+    search: false
 
     repo-url: https://github.com/pharmaR/pharmapkgs
     repo-actions: [issue]


### PR DESCRIPTION
## Issue

Closes #38 

## Description

As per the issue description, `search.json` is generated by quarto. This file pretty much contains the entire content of every report, split into sections. As a result, this file weighs >100mb and is not digestible by Github directly.

As of now I don't see any use for a full search mechanism, because a filter input to search by report title (which includes package name and version) seems to be sufficient. For this reason, I am disabling the search feature.

However, please note that even with `search: false` quarto still renders a `search.json` file. I will try to overcome this issue by git-removing existing `search.json` file from `gh-pages` branch, and adding it to `.gitignore`. My expectation is that when quarto renders a website, it then moves rendered files to `gh-pages` branch, but since `search.json` is now ignored, it won't be pushed.

## Note

For clarity, this is what changes from the web ui perspective:
![CleanShot 2025-02-26 at 10 37 38@2x](https://github.com/user-attachments/assets/bdd0035b-d54a-4d7a-9860-a0dce72560ca)
