### PR TITLE
chore: remove rstudio feature from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,9 +8,6 @@
       "installDevTools": true
     },
     "ghcr.io/rocker-org/devcontainer-features/r-dependent-packages:0": {},
-    "ghcr.io/rocker-org/devcontainer-features/rstudio-server:0": {
-      "version": "daily"
-    },
     "ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {
       "version": "1.7.13"
     }


### PR DESCRIPTION
This PR removes RStudio Server feature from the devcontainer configuration.